### PR TITLE
Added feature to publish euler angles to imu_euler topic direclty from BNO055 sensor

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
   <depend>tf_transformations</depend>
+  <depend>geometry_msgs</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <depend>tf_transformations</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2_bno055/bno055.py
+++ b/ros2_bno055/bno055.py
@@ -23,6 +23,7 @@ import rclpy.node
 from rclpy.exceptions import InvalidParameterValueException
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 from sensor_msgs.msg import Imu, MagneticField, Temperature
+from tf_transformations import euler_from_quaternion
 
 import board  # Adafruit Blinka
 import adafruit_bno055  # https://pypi.org/project/adafruit-circuitpython-bno055/
@@ -153,7 +154,12 @@ class BNO055Pub(rclpy.node.Node):
         bno055_quaternion = self.bno055.quaternion
         bno055_gyro = self.bno055.gyro
         bno055_linear_accel = self.bno055.linear_acceleration
-
+        # Convert to Euler angles (in radians)
+        yaw, pitch, roll = euler_from_quaternion(bno055_quaternion)            
+        
+        print(f"roll: {roll}, pitch: {pitch}, yaw: {yaw}")  
+        # Set the orientation in the message
+        
         for i, a in enumerate(['x', 'y', 'z', 'w']):
             setattr(msg.orientation, a, bno055_quaternion[i])
 

--- a/ros2_bno055/bno055.py
+++ b/ros2_bno055/bno055.py
@@ -157,8 +157,7 @@ class BNO055Pub(rclpy.node.Node):
         # Convert to Euler angles (in radians)
         yaw, pitch, roll = euler_from_quaternion(bno055_quaternion)            
         
-        print(f"roll: {roll}, pitch: {pitch}, yaw: {yaw}")  
-        # Set the orientation in the message
+        print(f"roll: {roll}, pitch: {pitch}, yaw: {yaw}")          #can be commented out if not needed
         
         for i, a in enumerate(['x', 'y', 'z', 'w']):
             setattr(msg.orientation, a, bno055_quaternion[i])

--- a/ros2_bno055/bno055.py
+++ b/ros2_bno055/bno055.py
@@ -24,6 +24,7 @@ from rclpy.exceptions import InvalidParameterValueException
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 from sensor_msgs.msg import Imu, MagneticField, Temperature
 from tf_transformations import euler_from_quaternion
+from geometry_msgs.msg import Vector3
 
 import board  # Adafruit Blinka
 import adafruit_bno055  # https://pypi.org/project/adafruit-circuitpython-bno055/
@@ -132,6 +133,7 @@ class BNO055Pub(rclpy.node.Node):
         self._imu_pub = self.create_publisher(Imu, "imu", 10)
         imu_rate = self.get_parameter("imu_update_rate").get_parameter_value().double_value
         self._imu_timer = self.create_timer(imu_rate, self.imu_timer_callback)
+        self._euler_imu_pub = self.create_publisher(Vector3, "imu_euler", 10)           #to publish euler angles
 
         self._mag_pub = self.create_publisher(MagneticField, "magnetometer", 10)
         mag_rate = self.get_parameter("mag_update_rate").get_parameter_value().double_value
@@ -155,9 +157,8 @@ class BNO055Pub(rclpy.node.Node):
         bno055_gyro = self.bno055.gyro
         bno055_linear_accel = self.bno055.linear_acceleration
         # Convert to Euler angles (in radians)
-        yaw, pitch, roll = euler_from_quaternion(bno055_quaternion)            
-        
-        print(f"roll: {roll}, pitch: {pitch}, yaw: {yaw}")          #can be commented out if not needed
+        yaw, pitch, roll = euler_from_quaternion(bno055_quaternion)  
+        #print(f"roll: {roll}, pitch: {pitch}, yaw: {yaw}")          #can be uncommented if needed
         
         for i, a in enumerate(['x', 'y', 'z', 'w']):
             setattr(msg.orientation, a, bno055_quaternion[i])
@@ -177,6 +178,10 @@ class BNO055Pub(rclpy.node.Node):
         msg.linear_acceleration_covariance = LINEAR_ACCELERATION_COVARIANCE
 
         self._imu_pub.publish(msg)
+        # Publish Euler angles to /imu_euler topic
+        euler_msg = Vector3()
+        euler_msg.x, euler_msg.y, euler_msg.z = roll, pitch, yaw
+        self._euler_imu_pub.publish(euler_msg)
 
     def mag_timer_callback(self) -> None:
         msg = MagneticField()


### PR DESCRIPTION
This pull request adds the functionality to publish Euler angles (roll, pitch, yaw) obtained from the BNO055 IMU to a new topic named /imu_euler. This enhancement improves interoperability with other ROS 2 tools and simplifies the integration of orientation data in downstream robotics applications.

- Topic: /imu_euler
- Type:` geometry_msgs/msg/Vector3

After building and sourcing the package, run the following commands to visualize the imu data of orientation in radians

```
ros2 run ros2_bno055 bno055
ros2 topic echo /imu_euler
```
🧪 Testing
  Verified publishing on /bno055_euler using ros2 topic echo.
  Confirmed correct mapping of roll, pitch, and yaw values as per the hardware of BNO055 sensor.